### PR TITLE
AUI-3145 Fix issue with charts tooltips

### DIFF
--- a/src/charts/js/ChartBase.js
+++ b/src/charts/js/ChartBase.js
@@ -640,15 +640,12 @@ ChartBase.prototype = {
                     }
                 }, this));
             }
-            else
-            {
-                Y.delegate("mouseenter", Y.bind(this._markerEventDispatcher, this), cb, markerClassName);
-                Y.delegate("mousedown", Y.bind(this._markerEventDispatcher, this), cb, markerClassName);
-                Y.delegate("mouseup", Y.bind(this._markerEventDispatcher, this), cb, markerClassName);
-                Y.delegate("mouseleave", Y.bind(this._markerEventDispatcher, this), cb, markerClassName);
-                Y.delegate("click", Y.bind(this._markerEventDispatcher, this), cb, markerClassName);
-                Y.delegate("mousemove", Y.bind(this._positionTooltip, this), cb, markerClassName);
-            }
+            Y.delegate("mouseenter", Y.bind(this._markerEventDispatcher, this), cb, markerClassName);
+            Y.delegate("mousedown", Y.bind(this._markerEventDispatcher, this), cb, markerClassName);
+            Y.delegate("mouseup", Y.bind(this._markerEventDispatcher, this), cb, markerClassName);
+            Y.delegate("mouseleave", Y.bind(this._markerEventDispatcher, this), cb, markerClassName);
+            Y.delegate("click", Y.bind(this._markerEventDispatcher, this), cb, markerClassName);
+            Y.delegate("mousemove", Y.bind(this._positionTooltip, this), cb, markerClassName);
         }
         else if(interactionType === "planar")
         {


### PR DESCRIPTION
 CC @joshuacords

[AUI-3145](https://issues.liferay.com/browse/AUI-3145)

Problem: In some cases charts tool tips would not appear in charts when the mouse is hovering over the graph. The issue is only reproducible in some browsers. On all browsers I tested on MAC the issue was not reproducible. It was also not reproducible in IE 11.

Solution: The issue was caused due to a touchend event being expected instead of a mouse over event. The tool tips would only work for either touch input or mouse input, but it would not work for both at the same time. Leaving the user thinking the tool tips was not functioning at all, when it actually just wasn't working for the input they are currently using.

I removed the else statement that was surrounding where the mouse events were being bound. This allows for the mouse event to be triggered even when touch input is enabled. So in cases where the user is on a machine that supports both touch and mouse input, tool tips will still appear from the mouse input as well as the touch input.  