### PR TITLE
LPS-99836 Remove 2nd initializer as it causes IE11 to error when comb…

### DIFF
--- a/src/widget-position-align/js/Widget-PositionAlign.js
+++ b/src/widget-position-align/js/Widget-PositionAlign.js
@@ -234,16 +234,6 @@ PositionAlign.prototype = {
 
     // -- Lifecycle Methods ----------------------------------------------------
 
-    initializer: function() {
-        if ( ! this._posNode) {
-            Y.error('WidgetPosition needs to be added to the Widget, ' +
-                'before WidgetPositionAlign is added');
-        }
-
-        Y.after(this._bindUIPosAlign, this, 'bindUI');
-        Y.after(this._syncUIPosAlign, this, 'syncUI');
-    },
-
     destructor: function () {
         this._detachPosAlignUIHandles();
     },


### PR DESCRIPTION
…ined with 'use strict';

https://issues.liferay.com/browse/LPS-99836

I found that when combo js files are used, the "use strict"; notation in many of our files conflicts in IE11 with Widget-PositionAlign's 2 initializers.