### PR TITLE
AUI-3187 Account for cssStampEl DOM placement to better follow HTML spec

### DIFF
--- a/src/yui/js/yui.js
+++ b/src/yui/js/yui.js
@@ -202,6 +202,10 @@ available.
             if (hasWin) {
                 remove(doc, 'DOMContentLoaded', handleReady);
             }
+
+            if (doc && doc.body && YUI.Env.cssStampEl && (!doc.body.contains(YUI.Env.cssStampEl))) {
+                doc.body.appendChild(YUI.Env.cssStampEl);
+            }
         },
         handleLoad = function() {
             YUI.Env.windowLoaded = true;


### PR DESCRIPTION
https://issues.liferay.com/browse/AUI-3187

Hi Frontend team,

YUI currently has logic that results in a div element being placed outside of the document body. This placement violates WCAG 2.0 guidelines and HTML spec.

For our testing, we are using W3C's validator (See [AUI-3187](https://issues.liferay.com/browse/AUI-3187) for more info). 

**Note:** This issue has also been discussed in the past in the original YUI3 repo: https://github.com/yui/yui3/issues/1373.

For additional information regarding the proposed changes, please see below.

Please let me know if you have any questions.
Thanks!

----

**Additional Info**
YUI introduces a div to register a CSS stamp element - [yui.js#L484-L496](https://github.com/liferay/yui3/blob/patched-v3.18.1/src/yui/js/yui.js#L484-L496)
```
//Register the CSS stamp element
if (doc && !doc.getElementById(CSS_STAMP_EL)) {
    el = doc.createElement('div');
    el.innerHTML = '<div id="' + CSS_STAMP_EL + '" style="position: absolute !important; visibility: hidden !important"></div>';
    YUI.Env.cssStampEl = el.firstChild;
    if (doc.body) {
        doc.body.appendChild(YUI.Env.cssStampEl);
    } else {
        docEl.insertBefore(YUI.Env.cssStampEl, docEl.firstChild);
    }
} else if (doc && doc.getElementById(CSS_STAMP_EL) && !YUI.Env.cssStampEl) {
    YUI.Env.cssStampEl = doc.getElementById(CSS_STAMP_EL);
}
```
YUI attempts to append the created CSS stamp element to the body, but only if the body is available in the DOM. Otherwise, it will add the CSS Stamp element to the main HTML element instead.

**Issue**
If YUI is being initialized before the body is created, it will add the CSS Stamp element to the main HTML element instead.

For Liferay's case, we initialize AUI in the header: [bnd.bnd#L32-L36](https://github.com/liferay/liferay-portal/blob/7.2.1-ga2/modules/apps/frontend-js/frontend-js-web/bnd.bnd#L32-L36). This means that YUI will always add the CSS Stamp element to the HTML element instead of the body.

**Proposed Solution**
From what I can tell, the cssStampEl is being used for:

- It's existence
- Element properties (such as classes)

It doesn't look like it's DOM placement/location is specifically being used in the YUI logic.

The only place I see it being used is in the method: isCSSLoaded
[loader.js#L1728-L1770](https://github.com/liferay/yui3/blob/patched-v3.18.1/src/loader/js/loader.js#L1728-L1770)

With that in mind, the proposed solution is to just move the cssStampEl into the body, when the body is available.