### PR TITLE
AUI-3203 Add semantic tag to minicalendar heading

### DIFF
--- a/src/calendar/js/calendar-base.js
+++ b/src/calendar/js/calendar-base.js
@@ -1481,9 +1481,9 @@ Y.CalendarBase = Y.extend( CalendarBase, Y.Widget, {
         * @static
         */
     HEADER_TEMPLATE: '<div class="yui3-g {calendar_hd_class}">' +
-                        '<div class="yui3-u {calendar_hd_label_class}" id="{calendar_id}_header" aria-role="heading">' +
+                        '<h1 class="yui3-u {calendar_hd_label_class}" id="{calendar_id}_header">' +
                             '{calheader}' +
-                        '</div>' +
+                        '</h1>' +
                     '</div>',
 
      /**


### PR DESCRIPTION
Hello,
Accessibility evaluation tool found an error. To meet the criteria, we can add aria-level to heading role.
https://issues.liferay.com/browse/AUI-3203

The other option is to add semantic heading element instead of the div. I am not sure which would be a better choice here.

Can you please review it?
Thanks!