### PR TITLE
AUI-3203 Fix attribute aria-role to role="heading"

### DIFF
--- a/src/calendar/assets/calendar-base/skins/sam/calendar-base-skin.css
+++ b/src/calendar/assets/calendar-base/skins/sam/calendar-base-skin.css
@@ -48,7 +48,7 @@
 
 .yui3-skin-sam .yui3-calendar-selection-disabled,
 .yui3-skin-sam .yui3-calendar-selection-disabled:hover {
-  color: #A6A6A6;
+  color: #717171;
   background: #CCCCCC;
 }
 
@@ -57,7 +57,7 @@
 }
 
 .yui3-skin-sam .yui3-calendar-prevmonth-day, .yui3-skin-sam .yui3-calendar-nextmonth-day {
-  color: #A6A6A6;
+  color: #717171;
 }
 
 .yui3-skin-sam .yui3-calendar-day {

--- a/src/calendar/js/calendar-base.js
+++ b/src/calendar/js/calendar-base.js
@@ -1481,7 +1481,7 @@ Y.CalendarBase = Y.extend( CalendarBase, Y.Widget, {
         * @static
         */
     HEADER_TEMPLATE: '<div class="yui3-g {calendar_hd_class}">' +
-                        '<div class="yui3-u {calendar_hd_label_class}" id="{calendar_id}_header" aria-role="heading">' +
+                        '<div class="yui3-u {calendar_hd_label_class}" id="{calendar_id}_header" role="heading" aria-level="2">' +
                             '{calheader}' +
                         '</div>' +
                     '</div>',


### PR DESCRIPTION
I would like to reopen https://github.com/liferay/yui3/pull/22

Because we use this inside tag lib liferay-ui:input-date and for 7.2.x we use inside dynamic data mapping for date picker.

I know we overwrote this for calendar under this [commit](https://github.com/liferay/liferay-portal/commit/1c2e32ca0d125a3e7d50ecd72dfb0194e75ba611) 

But we still need to fix this in at least two other places:
1. inside tag lib liferay-ui:input-date see https://github.com/liferay/liferay-portal/blob/8fa7d8bc2ad2058a2a7378f88ef33ae38b5a3619/portal-web/docroot/html/taglib/ui/input_date/page.jsp#L296
2. for dynamic data mapping date picker https://github.com/liferay/liferay-portal/blob/8fa7d8bc2ad2058a2a7378f88ef33ae38b5a3619/modules/apps/dynamic-data-mapping/dynamic-data-mapping-web/src/main/resources/META-INF/resources/js/custom_fields.js#L1285

Would like to ask if it is possible to fix it inside this repo, so we don't have so many work to fix in all the places we use this. 

Regards.