### PR TITLE
AUI-3216 Improve accessibility of arrow keys prev and next

### DIFF
--- a/src/calendar/js/calendarnavigator.js
+++ b/src/calendar/js/calendarnavigator.js
@@ -104,8 +104,8 @@ CalendarNavigator.CALENDARNAV_STRINGS = {
     * @protected
     * @static
     */
-CalendarNavigator.PREV_MONTH_CONTROL_TEMPLATE = '<a class="yui3-u {prev_month_class}" role="button" aria-label="{prev_month_arialabel}" ' +
-                                                    'tabindex="{control_tabindex}" />';
+CalendarNavigator.PREV_MONTH_CONTROL_TEMPLATE = '<a class="yui3-u {prev_month_class}" role="button" tabindex="{control_tabindex}">' +
+                                                    '<span class=”sr-only”>{prev_month_arialabel}</span></a>';
    /**
     * The template for the calendar navigator next month control.
     * @property NEXT_MONTH_CONTROL_TEMPLATE
@@ -114,8 +114,8 @@ CalendarNavigator.PREV_MONTH_CONTROL_TEMPLATE = '<a class="yui3-u {prev_month_cl
     * @protected
     * @static
     */
-CalendarNavigator.NEXT_MONTH_CONTROL_TEMPLATE = '<a class="yui3-u {next_month_class}" role="button" aria-label="{next_month_arialabel}" ' +
-                                                    'tabindex="{control_tabindex}" />';
+CalendarNavigator.NEXT_MONTH_CONTROL_TEMPLATE = '<a class="yui3-u {next_month_class}" role="button" tabindex="{control_tabindex}">' +
+                                                    '<span class=”sr-only”>{prev_month_arialabel}</span></a>';
 
 
 Y.extend(CalendarNavigator, Y.Plugin.Base, {


### PR DESCRIPTION
AUI-3216 Screen reader users have the link tag in their aria-label attribute available only by CSS, but people accessing without CSS or with custom CSS could have the link empty and as result inaccessible