### PR TITLE
fix: LPS-167272 set correct aria label for the next month button

### DIFF
--- a/src/calendar/js/calendarnavigator.js
+++ b/src/calendar/js/calendarnavigator.js
@@ -115,7 +115,7 @@ CalendarNavigator.PREV_MONTH_CONTROL_TEMPLATE = '<a class="yui3-u {prev_month_cl
     * @static
     */
 CalendarNavigator.NEXT_MONTH_CONTROL_TEMPLATE = '<a class="yui3-u {next_month_class}" role="button" tabindex="{control_tabindex}">' +
-                                                    '<span class="sr-only">{prev_month_arialabel}</span></a>';
+                                                    '<span class="sr-only">{next_month_arialabel}</span></a>';
 
 
 Y.extend(CalendarNavigator, Y.Plugin.Base, {


### PR DESCRIPTION
### References

- [LPS-167272 HR_45 Multiple events are being read in reverse order](https://issues.liferay.com/browse/LPS-167272)
- Related: https://github.com/liferay/liferay-frontend-projects/pull/1052

### What is the goal of this PR?

This change fixes part of the ticket, an incorrect aria label.

I liked below where the change will take place. I didn't test the change live, but it is a very simple fix and I'm confident there will be no issues.

![Screenshot from 2022-12-13 17-34-21](https://user-images.githubusercontent.com/5435511/207392466-8bc77fe6-9b4f-4376-9c91-81ee2232ade6.png)

