### PR TITLE
feat: make `script-src: 'unsafe-eval'` unnecessary in CSP

### DIFF
--- a/src/yui/js/yui.js
+++ b/src/yui/js/yui.js
@@ -527,7 +527,7 @@ proto = {
         // using eval(). This is critical for Content Security Policy enabled
         // sites and other environments like Chrome extensions
         if (!Y.config.hasOwnProperty('global')) {
-            Y.config.global = Function('return this')();
+            Y.config.global = window || global;
         }
     },
 


### PR DESCRIPTION
This is part of https://liferay.atlassian.net/browse/LPS-178066 and allows YUI to run in servers using a CSP that doesn't include `'unsafe-eval'`.