### PR TITLE
fix: Do not add aria-expanded attribute automatically to input fields

### DIFF
--- a/src/autocomplete/js/autocomplete-list.js
+++ b/src/autocomplete/js/autocomplete-list.js
@@ -135,7 +135,6 @@ List = Y.Base.create('autocompleteList', Y.Widget, [
 
         inputNode.addClass(this.getClassName('input')).setAttrs({
             'aria-autocomplete': LIST,
-            'aria-expanded'    : false,
             'aria-owns'        : listNode.get('id')
         });
 


### PR DESCRIPTION
Hey,

[LPS-196962](https://liferay.atlassian.net/browse/LPS-196962),

This is a fix for an accessibility issue reproduced in our calendar portlet.[ I've been asked to resolve the issue directly in YUI3](https://github.com/liferay-workflow/liferay-portal/pull/1006#discussion_r1358847376)
Please review my change.

Thank you,